### PR TITLE
feat: Enhance type for kiss msg

### DIFF
--- a/.changeset/ninety-comics-end.md
+++ b/.changeset/ninety-comics-end.md
@@ -1,0 +1,5 @@
+---
+'kiss-msg': patch
+---
+
+new two type friendly method `query` `method`

--- a/packages/kiss-msg/src/index.ts
+++ b/packages/kiss-msg/src/index.ts
@@ -1,15 +1,20 @@
 import { EventEmitter } from 'eventemitter3'
 import { client, kiss } from 'kiss-core'
 
-// const mg = client
+export interface MsgDto {
+  msg: string
+  data: any
+}
+
 export class MyEvent extends EventEmitter {
   ifUI: boolean
   ifMg: boolean
   ifMgUi: boolean
+
   constructor(
-        ifRenderUI = false,
-        ifMg = false,
-        ifMgUi = false,
+    ifRenderUI = false,
+    ifMg = false,
+    ifMgUi = false,
   ) {
     super()
     this.ifUI = ifRenderUI
@@ -33,7 +38,7 @@ export class MyEvent extends EventEmitter {
           window.onmessage = ev => receive(ev.data)
         }
         catch (e) {
-        //   console.log('err', e)
+          //   console.log('err', e)
         }
       }
       else {
@@ -62,7 +67,7 @@ export class MyEvent extends EventEmitter {
           window.parent.postMessage(postData, '*')
         }
         catch (e) {
-        //   console.log('err', e)
+          //   console.log('err', e)
         }
       }
       else {
@@ -74,14 +79,16 @@ export class MyEvent extends EventEmitter {
     }
   }
 
-  loadFirst(ev: any) {
-    return new Promise((resolve) => {
-      this.once(ev, resolve)
-    })
+  // type support
+  answer<T extends MsgDto>(event: T['msg'], handler: (data: T['data']) => void): this {
+    return super.on(event, handler)
+  }
+
+  query<T extends MsgDto>(event: T['msg'], data: T['data']) {
+    this.send(event, data)
   }
 }
 
 // console.log(kiss, kiss.inUi, kiss.inMgUi)
 export const io_ui = kiss.inUi ? new MyEvent(true, kiss.inMg, kiss.inMgUi) : undefined
 export const io_hook = kiss.inUi ? undefined : new MyEvent(false, kiss.inMg, kiss.inMgUi)
-

--- a/packages/kiss-msg/tsconfig.json
+++ b/packages/kiss-msg/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "strict": true,
+    "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
feat(kiss-msg): add type support

use example
```ts
import {io_ui,io_hook} from "kiss-msg"
import type {Msgdto} from "kiss-msg"

export interface Dto_Resize extends MsgDto{
  msg: 'UI_CHANGE_SIZE'
  body: {
    iconSize: number
    boxSize: number
  }
}

io_ui?.query<Dto_Resize>('UI_CHANGE_SIZE', toRaw(configApp))

io_hook?.answer<Dto_Resize>('UI_CHANGE_SIZE', (data) => {
  const sel = new SelParser().sel
  const resizer = new IconResizer(sel, data)
  resizer.run()
})

```
